### PR TITLE
Remove benchmarked package after job

### DIFF
--- a/gitlab.js
+++ b/gitlab.js
@@ -101,11 +101,13 @@ main:
     - cd ..
     - curl "${fallback}/api/report_started?repo=${repo}&pr=${pr}&commit=${commit}"
     - julia run.jl "${repo.split(".")[0]}" "${pr}" "${commit}" "${fallback}"
+    - julia -e "using Pkg; Pkg.rm(\\"${repo.split(".")[0]}\\")"
 
 failed_job:
   stage: second
   script:
     - curl "${fallback}/api/report_failed?repo=${repo}&pr=${pr}&commit=${commit}"
+    - julia -e "using Pkg; Pkg.rm(\\"${repo.split(".")[0]}\\")"
   when: on_failure
 
 `


### PR DESCRIPTION
As we work upon all the jobs in the same Julia environment, we need to remove the package we checked out after the job is done, or else the next job for some other repo will use this checked out branch instead of master.
For eg - 
1. We benchmarked DiffEqBase on a branch A.
2. Then after some time the master of DiffEqBase got changed.
3. Now if we run OrdinaryDiffEq, it will use the checked out version of DiffEqBase.

This PR solves this issue. But we should use different environments for each job to solve this issue once for all.
Already deployed to heroku.